### PR TITLE
Add ARM firewall management web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# ARM-
+# ARM 设备防火墙管理工具
+
+本项目提供一个在 Windows 10 平台运行的 Web 管理界面，
+通过 SSH 访问 ARMv7l 设备并使用 `iptables` 命令获取、整理
+以及维护防火墙规则。
+
+## 功能特性
+
+- 通过 `iptables -L -n --line-numbers` 自动分类整理链和规则。
+- 支持将规则按链、按动作（目标）两种视图方式展示，界面简洁美观。
+- 支持快速搜索端口、源/目的地址等关键信息。
+- 支持新增、编辑（替换）与删除规则。
+- 通过 Bootstrap 打造响应式界面，桌面与移动端均可友好展示。
+
+## 快速开始
+
+### 1. 准备运行环境
+
+1. 安装 [Python 3.10+](https://www.python.org/downloads/windows/)（建议勾选
+   `Add python.exe to PATH`）。
+2. 安装依赖：
+
+   ```powershell
+   cd <项目目录>
+   python -m venv .venv
+   .venv\Scripts\Activate.ps1
+   pip install -r requirements.txt
+   ```
+
+### 2. 配置连接信息
+
+1. 将 `config.example.json` 复制为 `config.json`。
+2. 修改以下字段以匹配 ARM 设备信息：
+   - `host`：设备 IP 或域名。
+   - `username` / `password`：SSH 凭据（也可配置 `key_filename` 使用密钥登录）。
+   - `port`：SSH 端口，默认 22。
+   - `timeout`：连接超时时间（秒）。
+   - `list_command`：获取规则的命令，默认 `iptables -L -n --line-numbers`。
+
+### 3. 启动服务
+
+```powershell
+flask --app app run --host 0.0.0.0 --port 8000
+```
+
+或直接运行：
+
+```powershell
+python app.py
+```
+
+浏览器访问 `http://localhost:8000` 即可打开管理界面。
+
+### 4. 管理防火墙规则
+
+- **新增规则**：在左侧表单中选择链（如 INPUT），填写链后的参数片段
+  （如 `-p tcp --dport 8080 -j ACCEPT`），可选地指定插入位置。
+- **编辑规则**：在规则行中选择“编辑”后输入新的参数片段，系统将使用
+  `iptables -R` 替换原规则。
+- **删除规则**：点击“删除”将通过 `iptables -D` 删除对应行号的规则。
+- **重新整理视图**：通过右侧“按链显示 / 重新整理（按动作）”切换视图，
+  可以快速掌握不同动作（如 ACCEPT、DROP）对应的所有规则。
+
+## 测试
+
+解析器可直接使用提供的示例输出进行测试：
+
+```powershell
+pytest
+```
+
+## 安全注意事项
+
+- 默认配置使用密码登录，建议在生产环境中改用 SSH 密钥并限制访问源。
+- 所有操作均直接对真实防火墙生效，执行前请确认命令正确。
+- 可结合系统任务计划或备份脚本定期导出 `iptables-save` 结果。
+
+## 许可证
+
+MIT License

--- a/app.py
+++ b/app.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+from flask import Flask, jsonify, render_template, request
+from werkzeug.exceptions import HTTPException
+
+from firewall_client import FirewallClient, FirewallCommandError, SSHConfig
+from firewall_parser import FirewallChain
+
+app = Flask(__name__, static_folder="static", template_folder="templates")
+
+
+def _config_path() -> Path:
+    return Path(__file__).with_name("config.json")
+
+
+@lru_cache(maxsize=1)
+def _client() -> FirewallClient:
+    config_file = _config_path()
+    if not config_file.exists():
+        raise FileNotFoundError(
+            "Missing config.json. Copy config.example.json and update it with "
+            "the remote device credentials."
+        )
+    return FirewallClient(SSHConfig.from_file(config_file))
+
+
+@app.route("/")
+def index() -> str:
+    return render_template("index.html")
+
+
+def _serialize_chain(chain: FirewallChain) -> Dict[str, Any]:
+    return {
+        "name": chain.name,
+        "policy": chain.policy,
+        "references": chain.references,
+        "rules": [
+            {
+                "number": rule.number,
+                "target": rule.target,
+                "protocol": rule.protocol,
+                "option": rule.option,
+                "source": rule.source,
+                "destination": rule.destination,
+                "details": [
+                    {"label": detail.label, "value": detail.value}
+                    for detail in rule.details
+                ],
+                "raw": rule.raw,
+            }
+            for rule in chain.rules
+        ],
+    }
+
+
+@app.route("/api/rules", methods=["GET"])
+def list_rules() -> Any:
+    try:
+        chains = _client().fetch_chains()
+    except FileNotFoundError as exc:
+        return jsonify({"error": str(exc)}), 500
+    except FirewallCommandError as exc:
+        return jsonify({"error": str(exc)}), 500
+    return jsonify({"chains": [_serialize_chain(chain) for chain in chains]})
+
+
+@app.route("/api/rules", methods=["POST"])
+def add_rule() -> Any:
+    payload: Dict[str, Any] = request.get_json(force=True)
+    chain = payload.get("chain")
+    specification = payload.get("specification")
+    position = payload.get("position")
+
+    if not chain or not specification:
+        return jsonify({"error": "chain and specification are required"}), 400
+
+    try:
+        _client().add_rule(chain, specification, position)
+    except FirewallCommandError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/api/rules/<chain>/<int:number>", methods=["PUT"])
+def replace_rule(chain: str, number: int) -> Any:
+    payload: Dict[str, Any] = request.get_json(force=True)
+    specification = payload.get("specification")
+    if not specification:
+        return jsonify({"error": "specification is required"}), 400
+
+    try:
+        _client().replace_rule(chain, number, specification)
+    except FirewallCommandError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"status": "ok"})
+
+
+@app.route("/api/rules/<chain>/<int:number>", methods=["DELETE"])
+def delete_rule(chain: str, number: int) -> Any:
+    try:
+        _client().delete_rule(chain, number)
+    except FirewallCommandError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"status": "ok"})
+
+
+@app.errorhandler(Exception)
+def handle_exception(exc: Exception) -> Any:
+    if isinstance(exc, HTTPException):
+        if request.path.startswith("/api/"):
+            return jsonify({"error": exc.description}), exc.code
+        return exc
+
+    app.logger.exception("Unhandled error: %s", exc)
+    if request.path.startswith("/api/"):
+        return jsonify({"error": str(exc)}), 500
+    raise exc
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,8 @@
+{
+  "host": "192.168.50.1",
+  "username": "admin",
+  "password": "your-password",
+  "port": 22,
+  "timeout": 10,
+  "list_command": "iptables -L -n --line-numbers"
+}

--- a/firewall_client.py
+++ b/firewall_client.py
@@ -1,0 +1,109 @@
+"""SSH client wrapper for interacting with iptables on remote ARM devices."""
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import paramiko
+
+from firewall_parser import FirewallChain, parse_iptables_output
+
+
+class FirewallCommandError(RuntimeError):
+    """Raised when an iptables command fails on the remote host."""
+
+    def __init__(self, command: Iterable[str], exit_status: int, stderr: str) -> None:
+        self.command = list(command)
+        self.exit_status = exit_status
+        self.stderr = stderr
+        super().__init__(
+            f"Command '{' '.join(self.command)}' failed with exit status "
+            f"{exit_status}: {stderr.strip()}"
+        )
+
+
+@dataclass
+class SSHConfig:
+    host: str
+    username: str
+    password: Optional[str] = None
+    port: int = 22
+    key_filename: Optional[str] = None
+    timeout: int = 10
+    list_command: str = "iptables -L -n --line-numbers"
+
+    @classmethod
+    def from_file(cls, path: Path) -> "SSHConfig":
+        with path.open("r", encoding="utf-8") as fh:
+            payload: Dict[str, Any] = json.load(fh)
+        return cls(**payload)
+
+
+class FirewallClient:
+    """High-level interface for managing iptables rules over SSH."""
+
+    def __init__(self, config: SSHConfig) -> None:
+        self.config = config
+
+    @classmethod
+    def from_config_file(cls, path: Path) -> "FirewallClient":
+        config = SSHConfig.from_file(path)
+        return cls(config)
+
+    def _connect(self) -> paramiko.SSHClient:
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(
+            hostname=self.config.host,
+            port=self.config.port,
+            username=self.config.username,
+            password=self.config.password,
+            key_filename=self.config.key_filename,
+            timeout=self.config.timeout,
+        )
+        return client
+
+    def _run(self, command: Iterable[str] | str) -> str:
+        if isinstance(command, str):
+            command = shlex.split(command)
+        command = list(command)
+        with self._connect() as client:
+            stdin, stdout, stderr = client.exec_command(" ".join(shlex.quote(part) for part in command))
+            stdout_data = stdout.read().decode("utf-8", errors="replace")
+            stderr_data = stderr.read().decode("utf-8", errors="replace")
+            exit_status = stdout.channel.recv_exit_status()
+        if exit_status != 0:
+            raise FirewallCommandError(command, exit_status, stderr_data)
+        return stdout_data
+
+    def fetch_chains(self) -> List[FirewallChain]:
+        output = self._run(self.config.list_command)
+        return parse_iptables_output(output)
+
+    def add_rule(self, chain: str, specification: str, position: Optional[int] = None) -> None:
+        command: List[str] = ["iptables"]
+        if position is not None:
+            command += ["-I", chain, str(position)]
+        else:
+            command += ["-A", chain]
+        command += shlex.split(specification)
+        self._run(command)
+
+    def replace_rule(self, chain: str, number: int, specification: str) -> None:
+        command: List[str] = ["iptables", "-R", chain, str(number)]
+        command += shlex.split(specification)
+        self._run(command)
+
+    def delete_rule(self, chain: str, number: int) -> None:
+        command = ["iptables", "-D", chain, str(number)]
+        self._run(command)
+
+
+__all__ = [
+    "FirewallClient",
+    "FirewallCommandError",
+    "SSHConfig",
+]

--- a/firewall_parser.py
+++ b/firewall_parser.py
@@ -1,0 +1,196 @@
+"""Utilities for parsing iptables output into structured data."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import re
+
+
+@dataclass
+class RuleDetail:
+    label: str
+    value: Optional[str] = None
+
+
+@dataclass
+class FirewallRule:
+    number: int
+    target: str
+    protocol: str
+    option: str
+    source: str
+    destination: str
+    details: List[RuleDetail] = field(default_factory=list)
+    raw: str = ""
+
+
+@dataclass
+class FirewallChain:
+    name: str
+    policy: Optional[str] = None
+    references: Optional[int] = None
+    rules: List[FirewallRule] = field(default_factory=list)
+
+
+CHAIN_HEADER_RE = re.compile(r"^Chain\s+(?P<name>\S+)\s+\((?P<descriptor>[^)]*)\)")
+
+
+def _parse_chain_descriptor(descriptor: str) -> Dict[str, Optional[str]]:
+    result: Dict[str, Optional[str]] = {"policy": None, "references": None}
+    descriptor = descriptor.strip()
+    policy_match = re.search(r"policy\s+(?P<policy>\S+)", descriptor)
+    if policy_match:
+        result["policy"] = policy_match.group("policy")
+
+    ref_match = re.search(r"(?P<count>\d+)\s+references", descriptor)
+    if ref_match:
+        result["references"] = int(ref_match.group("count"))
+
+    return result
+
+
+BREAK_AFTER_VALUE = {"TCPMSS"}
+
+
+def _parse_rule_details(extra: List[str]) -> List[RuleDetail]:
+    details: List[RuleDetail] = []
+    prefix_parts: List[str] = []
+
+    def push(label: str, value_tokens: List[str]) -> None:
+        value = " ".join(value_tokens).strip() if value_tokens else None
+        details.append(RuleDetail(label=label.strip(), value=value or None))
+
+    i = 0
+    length = len(extra)
+    while i < length:
+        token = extra[i]
+
+        if ":" in token:
+            label_part, value_part = token.split(":", 1)
+            label = " ".join(prefix_parts + [label_part]).strip()
+            prefix_parts = []
+
+            value_tokens: List[str] = [value_part] if value_part else []
+            i += 1
+            while i < length:
+                lookahead = extra[i]
+                if ":" in lookahead or lookahead.endswith(":"):
+                    break
+                if lookahead in BREAK_AFTER_VALUE and value_tokens:
+                    break
+                value_tokens.append(lookahead)
+                i += 1
+
+            push(label or label_part, value_tokens)
+            continue
+
+        # token without colon may serve as prefix for the next colon token
+        if i + 1 < length and ":" in extra[i + 1]:
+            prefix_parts.append(token)
+            i += 1
+            continue
+
+        label_tokens = prefix_parts + [token]
+        prefix_parts = []
+        i += 1
+        value_tokens: List[str] = []
+        while i < length:
+            lookahead = extra[i]
+            if ":" in lookahead or lookahead.endswith(":"):
+                break
+            if lookahead in BREAK_AFTER_VALUE and value_tokens:
+                break
+            value_tokens.append(lookahead)
+            i += 1
+
+        push(" ".join(label_tokens), value_tokens)
+
+    if prefix_parts:
+        push(" ".join(prefix_parts), [])
+
+    return details
+
+
+def parse_iptables_output(output: str) -> List[FirewallChain]:
+    """Parse the raw output of ``iptables -L -n --line-numbers``.
+
+    Args:
+        output: Raw command output.
+
+    Returns:
+        Structured representation grouped by chain.
+    """
+    chains: List[FirewallChain] = []
+    current_chain: Optional[FirewallChain] = None
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        header_match = CHAIN_HEADER_RE.match(stripped)
+        if header_match:
+            descriptor = header_match.group("descriptor")
+            chain_info = _parse_chain_descriptor(descriptor)
+            current_chain = FirewallChain(
+                name=header_match.group("name"),
+                policy=chain_info.get("policy"),
+                references=chain_info.get("references"),
+            )
+            chains.append(current_chain)
+            continue
+
+        if stripped.startswith("num ") or stripped.startswith("target "):
+            # Header rows inside the chain; skip them.
+            continue
+
+        if current_chain is None:
+            # Defensive: skip any rule lines before a chain header.
+            continue
+
+        parts = stripped.split()
+        if len(parts) < 6:
+            # Unexpected format; keep as raw detail entry.
+            rule = FirewallRule(
+                number=0,
+                target=stripped,
+                protocol="",
+                option="",
+                source="",
+                destination="",
+                details=[RuleDetail(label=stripped)],
+                raw=stripped,
+            )
+            current_chain.rules.append(rule)
+            continue
+
+        number = int(parts[0])
+        target = parts[1]
+        protocol = parts[2]
+        option = parts[3]
+        source = parts[4]
+        destination = parts[5]
+        extra = parts[6:]
+        details = _parse_rule_details(extra) if extra else []
+
+        rule = FirewallRule(
+            number=number,
+            target=target,
+            protocol=protocol,
+            option=option,
+            source=source,
+            destination=destination,
+            details=details,
+            raw=stripped,
+        )
+        current_chain.rules.append(rule)
+
+    return chains
+
+
+__all__ = [
+    "FirewallChain",
+    "FirewallRule",
+    "RuleDetail",
+    "parse_iptables_output",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.2
+paramiko==3.4.0
+pytest==8.1.1

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,96 @@
+body {
+  background-color: #f7f8fb;
+}
+
+.navbar-brand {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.card {
+  border: none;
+  border-radius: 1rem;
+}
+
+.card-header {
+  border-bottom: none;
+  border-top-left-radius: 1rem !important;
+  border-top-right-radius: 1rem !important;
+}
+
+.table thead th {
+  background-color: #f0f4ff;
+  border: none;
+}
+
+.rule-detail-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background-color: #eef2ff;
+  color: #1d4ed8;
+}
+
+.rule-detail-badge span {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.chain-badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.chain-badge[data-chain="INPUT"] {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.chain-badge[data-chain="FORWARD"] {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.chain-badge[data-chain="OUTPUT"] {
+  background-color: #e0f2fe;
+  color: #0c4a6e;
+}
+
+.chain-badge[data-chain] {
+  background-color: #f1f5f9;
+  color: #475569;
+}
+
+.rule-actions button {
+  min-width: 90px;
+}
+
+#rulesContainer .card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#rulesContainer .card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.target-section {
+  border-left: 4px solid #2563eb;
+  padding-left: 1.25rem;
+}
+
+.target-section h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+@media (max-width: 991.98px) {
+  .card {
+    border-radius: 1rem;
+  }
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,350 @@
+const state = {
+  chains: [],
+  viewMode: "chain",
+  search: "",
+  loading: false,
+};
+
+const rulesContainer = document.getElementById("rulesContainer");
+const errorAlert = document.getElementById("errorAlert");
+const refreshButton = document.getElementById("refreshButton");
+const addRuleForm = document.getElementById("addRuleForm");
+const searchInput = document.getElementById("searchInput");
+const viewChains = document.getElementById("viewChains");
+const viewTargets = document.getElementById("viewTargets");
+
+function setLoading(isLoading) {
+  state.loading = isLoading;
+  refreshButton.disabled = isLoading;
+  refreshButton.textContent = isLoading ? "刷新中..." : "立即刷新";
+}
+
+async function fetchRules() {
+  setLoading(true);
+  hideError();
+  try {
+    const response = await fetch("/api/rules");
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || "获取规则失败");
+    }
+    state.chains = data.chains || [];
+    render();
+  } catch (error) {
+    showError(error.message);
+  } finally {
+    setLoading(false);
+  }
+}
+
+function showError(message) {
+  errorAlert.textContent = message;
+  errorAlert.classList.remove("d-none");
+}
+
+function hideError() {
+  errorAlert.classList.add("d-none");
+  errorAlert.textContent = "";
+}
+
+function handleAddRule(event) {
+  event.preventDefault();
+  const formData = new FormData(addRuleForm);
+  const payload = {
+    chain: formData.get("chain").trim(),
+    specification: formData.get("specification").trim(),
+  };
+  const position = formData.get("position");
+  if (position) {
+    payload.position = Number(position);
+  }
+
+  fetch("/api/rules", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+    .then(async (response) => {
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "添加规则失败");
+      }
+      addRuleForm.reset();
+      fetchRules();
+    })
+    .catch((error) => {
+      showError(error.message);
+    });
+}
+
+function confirmAndDelete(chain, number) {
+  if (!confirm(`确定删除 ${chain} 链中的第 ${number} 条规则吗？`)) {
+    return;
+  }
+  fetch(`/api/rules/${encodeURIComponent(chain)}/${number}`, {
+    method: "DELETE",
+  })
+    .then(async (response) => {
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "删除规则失败");
+      }
+      fetchRules();
+    })
+    .catch((error) => showError(error.message));
+}
+
+function editRule(chain, number) {
+  const specification = prompt(
+    `请输入替换 ${chain} 链第 ${number} 条规则的参数片段：`
+  );
+  if (!specification) {
+    return;
+  }
+  fetch(`/api/rules/${encodeURIComponent(chain)}/${number}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ specification }),
+  })
+    .then(async (response) => {
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "更新规则失败");
+      }
+      fetchRules();
+    })
+    .catch((error) => showError(error.message));
+}
+
+function filterChains() {
+  if (!state.search) {
+    return state.chains;
+  }
+  const keyword = state.search.toLowerCase();
+  return state.chains
+    .map((chain) => ({
+      ...chain,
+      rules: chain.rules.filter((rule) =>
+        [
+          rule.target,
+          rule.protocol,
+          rule.option,
+          rule.source,
+          rule.destination,
+          rule.raw,
+          ...(rule.details || []).map((detail) =>
+            `${detail.label || ""}${detail.value ? ":" + detail.value : ""}`
+          ),
+        ]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(keyword))
+      ),
+    }))
+    .filter((chain) => chain.rules.length > 0);
+}
+
+function createDetailBadges(details) {
+  if (!details || details.length === 0) {
+    return "";
+  }
+  return `
+    <div class="d-flex flex-wrap gap-2">
+      ${details
+        .map((detail) => {
+          const value = detail.value ? `<span>${detail.value}</span>` : "";
+          return `<span class="rule-detail-badge">${detail.label}${value}</span>`;
+        })
+        .join("")}
+    </div>
+  `;
+}
+
+function renderChainView(chains) {
+  if (!chains.length) {
+    rulesContainer.innerHTML = `
+      <div class="text-center text-muted py-5">
+        <p class="mb-0">没有符合条件的规则。</p>
+      </div>`;
+    return;
+  }
+
+  rulesContainer.innerHTML = chains
+    .map((chain) => {
+      const headerMeta = [
+        chain.policy ? `策略：<strong>${chain.policy}</strong>` : null,
+        typeof chain.references === "number"
+          ? `引用：<strong>${chain.references}</strong>`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      const rows = chain.rules
+        .map(
+          (rule) => `
+            <tr>
+              <td class="fw-semibold">${rule.number}</td>
+              <td>${rule.target}</td>
+              <td>${rule.protocol}</td>
+              <td>${rule.option}</td>
+              <td>${rule.source}</td>
+              <td>${rule.destination}</td>
+              <td>${createDetailBadges(rule.details)}</td>
+              <td class="rule-actions text-end">
+                <button class="btn btn-sm btn-outline-secondary me-2" data-action="edit" data-chain="${chain.name}" data-number="${rule.number}">编辑</button>
+                <button class="btn btn-sm btn-outline-danger" data-action="delete" data-chain="${chain.name}" data-number="${rule.number}">删除</button>
+              </td>
+            </tr>
+          `
+        )
+        .join("");
+
+      return `
+        <div class="card shadow-sm">
+          <div class="card-header d-flex justify-content-between align-items-center bg-white">
+            <div>
+              <h2 class="h5 mb-1">
+                ${chain.name}
+                <span class="chain-badge" data-chain="${chain.name}">${chain.name}</span>
+              </h2>
+              <div class="text-muted small">${headerMeta || ""}</div>
+            </div>
+            <button class="btn btn-sm btn-outline-primary" data-action="refresh">刷新此链</button>
+          </div>
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-hover mb-0 align-middle">
+                <thead>
+                  <tr>
+                    <th style="width: 60px">#</th>
+                    <th>目标</th>
+                    <th>协议</th>
+                    <th>选项</th>
+                    <th>源地址</th>
+                    <th>目的地址</th>
+                    <th>详细信息</th>
+                    <th style="width: 180px" class="text-end">操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${rows}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderTargetView(chains) {
+  const targetMap = new Map();
+  chains.forEach((chain) => {
+    chain.rules.forEach((rule) => {
+      if (!targetMap.has(rule.target)) {
+        targetMap.set(rule.target, []);
+      }
+      targetMap.get(rule.target).push({ chain, rule });
+    });
+  });
+
+  if (targetMap.size === 0) {
+    rulesContainer.innerHTML = `
+      <div class="text-center text-muted py-5">
+        <p class="mb-0">没有符合条件的规则。</p>
+      </div>`;
+    return;
+  }
+
+  const sections = Array.from(targetMap.entries())
+    .map(([target, entries]) => {
+      const items = entries
+        .map(({ chain, rule }) => `
+          <div class="card shadow-sm mb-3">
+            <div class="card-body">
+              <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
+                <div>
+                  <h4 class="h6 mb-1">链：<span class="chain-badge" data-chain="${chain.name}">${chain.name}</span></h4>
+                  <div class="text-muted small">规则编号：${rule.number}</div>
+                </div>
+                <div class="rule-actions">
+                  <button class="btn btn-sm btn-outline-secondary me-2" data-action="edit" data-chain="${chain.name}" data-number="${rule.number}">编辑</button>
+                  <button class="btn btn-sm btn-outline-danger" data-action="delete" data-chain="${chain.name}" data-number="${rule.number}">删除</button>
+                </div>
+              </div>
+              <div class="mt-3">
+                <div class="fw-semibold">源地址：${rule.source}</div>
+                <div class="fw-semibold">目的地址：${rule.destination}</div>
+                <div class="text-muted mt-2">协议：${rule.protocol}｜选项：${rule.option}</div>
+              </div>
+              <div class="mt-3">${createDetailBadges(rule.details)}</div>
+            </div>
+          </div>
+        `)
+        .join("");
+
+      return `
+        <section class="target-section">
+          <h3 class="mb-3">目标：${target}</h3>
+          ${items}
+        </section>
+      `;
+    })
+    .join("");
+
+  rulesContainer.innerHTML = sections;
+}
+
+function render() {
+  const chains = filterChains();
+  if (state.viewMode === "chain") {
+    renderChainView(chains);
+  } else {
+    renderTargetView(chains);
+  }
+}
+
+refreshButton.addEventListener("click", fetchRules);
+addRuleForm.addEventListener("submit", handleAddRule);
+viewChains.addEventListener("change", () => {
+  if (viewChains.checked) {
+    state.viewMode = "chain";
+    render();
+  }
+});
+viewTargets.addEventListener("change", () => {
+  if (viewTargets.checked) {
+    state.viewMode = "target";
+    render();
+  }
+});
+
+searchInput.addEventListener("input", (event) => {
+  state.search = event.target.value;
+  render();
+});
+
+rulesContainer.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-action]");
+  if (!button) {
+    return;
+  }
+  const action = button.dataset.action;
+  const chain = button.dataset.chain;
+  const number = button.dataset.number;
+
+  if (action === "delete") {
+    confirmAndDelete(chain, Number(number));
+  } else if (action === "edit") {
+    editRule(chain, Number(number));
+  } else if (action === "refresh") {
+    fetchRules();
+  }
+});
+
+fetchRules();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ARM 设备防火墙管理工具</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="/static/css/styles.css" />
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container-fluid">
+        <span class="navbar-brand">ARM 设备防火墙管理工具</span>
+        <div class="d-flex gap-2">
+          <button id="refreshButton" class="btn btn-light btn-sm">
+            立即刷新
+          </button>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container py-4">
+      <div class="row g-4">
+        <section class="col-12 col-lg-4">
+          <div class="card shadow-sm">
+            <div class="card-header bg-white">
+              <h2 class="h5 mb-0">新增规则</h2>
+            </div>
+            <div class="card-body">
+              <form id="addRuleForm" class="vstack gap-3">
+                <div>
+                  <label class="form-label" for="chainInput">链 (Chain)</label>
+                  <input
+                    class="form-control"
+                    id="chainInput"
+                    name="chain"
+                    placeholder="如：INPUT"
+                    required
+                  />
+                </div>
+                <div>
+                  <label class="form-label" for="specInput">规则参数</label>
+                  <textarea
+                    class="form-control"
+                    id="specInput"
+                    name="specification"
+                    rows="3"
+                    placeholder="例如：-p tcp --dport 8080 -j ACCEPT"
+                    required
+                  ></textarea>
+                  <div class="form-text">
+                    这里填写 <code>iptables</code> 命令中链名称后的参数片段。
+                  </div>
+                </div>
+                <div>
+                  <label class="form-label" for="positionInput">插入位置 (可选)</label>
+                  <input
+                    type="number"
+                    min="1"
+                    class="form-control"
+                    id="positionInput"
+                    name="position"
+                    placeholder="不填则追加到链尾"
+                  />
+                </div>
+                <button class="btn btn-primary" type="submit">添加规则</button>
+              </form>
+            </div>
+          </div>
+          <div class="card shadow-sm mt-4">
+            <div class="card-header bg-white">
+              <h2 class="h5 mb-0">视图选项</h2>
+            </div>
+            <div class="card-body vstack gap-2">
+              <div class="btn-group" role="group">
+                <input
+                  type="radio"
+                  class="btn-check"
+                  name="viewOption"
+                  id="viewChains"
+                  autocomplete="off"
+                  checked
+                />
+                <label class="btn btn-outline-primary" for="viewChains">
+                  按链显示
+                </label>
+                <input
+                  type="radio"
+                  class="btn-check"
+                  name="viewOption"
+                  id="viewTargets"
+                  autocomplete="off"
+                />
+                <label class="btn btn-outline-primary" for="viewTargets">
+                  重新整理（按动作）
+                </label>
+              </div>
+              <div>
+                <label class="form-label" for="searchInput">快速搜索</label>
+                <input
+                  type="search"
+                  class="form-control"
+                  id="searchInput"
+                  placeholder="输入端口、目标或 IP 过滤"
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="col-12 col-lg-8">
+          <div id="errorAlert" class="alert alert-danger d-none" role="alert"></div>
+          <div id="rulesContainer" class="vstack gap-4"></div>
+        </section>
+      </div>
+    </main>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
+    <script src="/static/js/app.js"></script>
+  </body>
+</html>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from firewall_parser import parse_iptables_output
+
+SAMPLE = """Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination
+1    DROP       tcp  --  127.0.0.1            127.0.0.1            tcp dpt:48461
+2    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            udp dpts:25560:25570
+3    ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:200
+
+Chain FORWARD (policy DROP)
+num  target     prot opt source               destination
+1    TCPMSS     tcp  --  0.0.0.0/0            0.0.0.0/0            tcpflags: 0x06/0x02 TCPMSS clamp to PMTU
+2    ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED
+
+Chain OUTPUT (policy ACCEPT)
+num  target     prot opt source               destination
+1    OUTPUT_DNS  udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:53 u32 "0x0>>0x16&0x3c@0x8>>0xf&0x1=0x0"
+"""
+
+
+def test_parse_basic_structure():
+    chains = parse_iptables_output(SAMPLE)
+    assert [chain.name for chain in chains] == ["INPUT", "FORWARD", "OUTPUT"]
+
+    input_chain = chains[0]
+    assert input_chain.policy == "ACCEPT"
+    assert len(input_chain.rules) == 3
+    assert input_chain.rules[0].details[0].label == "tcp dpt"
+    assert input_chain.rules[0].details[0].value == "48461"
+
+    forward_chain = chains[1]
+    assert forward_chain.policy == "DROP"
+    assert forward_chain.rules[0].details[0].label == "tcpflags"
+    assert forward_chain.rules[0].details[0].value == "0x06/0x02"
+
+
+def test_details_grouping_for_tokens_without_colon():
+    chains = parse_iptables_output(SAMPLE)
+    rule = chains[1].rules[0]
+    # "TCPMSS clamp to PMTU" should keep "TCPMSS" label with value "clamp"
+    labels = [detail.label for detail in rule.details]
+    values = [detail.value for detail in rule.details]
+    assert "TCPMSS" in labels
+    assert any(value and "clamp" in value for value in values)


### PR DESCRIPTION
## Summary
- build a Flask backend that connects to the ARM device via SSH, parses `iptables -L -n --line-numbers`, and exposes CRUD endpoints for rules
- create a Bootstrap-based frontend to refresh, search, regroup, and manage firewall rules directly from the browser
- document Windows setup steps and add parser unit tests covering rule parsing edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc1c14fb78832b880a3d2b22e274e6