### PR TITLE
Add modal-based rule editor and expose detail keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,11 @@ def _serialize_chain(chain: FirewallChain) -> Dict[str, Any]:
                 "source": rule.source,
                 "destination": rule.destination,
                 "details": [
-                    {"label": detail.label, "value": detail.value}
+                    {
+                        "label": detail.label,
+                        "value": detail.value,
+                        **({"key": detail.key} if detail.key else {}),
+                    }
                     for detail in rule.details
                 ],
                 "raw": rule.raw,

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,89 @@
       </div>
     </main>
 
+    <div
+      class="modal fade"
+      id="ruleModal"
+      tabindex="-1"
+      aria-labelledby="ruleModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <form class="modal-content" id="ruleModalForm">
+          <div class="modal-header">
+            <h5 class="modal-title" id="ruleModalLabel">编辑规则</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="关闭"
+            ></button>
+          </div>
+          <div class="modal-body">
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label" for="ruleChainSelect">链 (Chain)</label>
+                <select class="form-select" id="ruleChainSelect" required></select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleTargetSelect">行为 (Target)</label>
+                <select class="form-select" id="ruleTargetSelect" required></select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleProtocolSelect">协议</label>
+                <select class="form-select" id="ruleProtocolSelect"></select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleSourceSelect">源地址</label>
+                <select class="form-select" id="ruleSourceSelect"></select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleDestinationSelect">目的地址</label>
+                <select class="form-select" id="ruleDestinationSelect"></select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleSourcePortInput">源端口</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="ruleSourcePortInput"
+                  placeholder="如：80 或 1000:2000"
+                />
+              </div>
+              <div class="col-md-6">
+                <label class="form-label" for="ruleDestinationPortInput">目的端口</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="ruleDestinationPortInput"
+                  placeholder="如：443"
+                />
+              </div>
+            </div>
+            <div class="mt-3">
+              <label class="form-label" for="ruleAdvancedInput"
+                >备注 / 高级参数 (可选)</label
+              >
+              <textarea
+                class="form-control"
+                id="ruleAdvancedInput"
+                rows="3"
+                placeholder="例如：-m state --state NEW"
+              ></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+              取消
+            </button>
+            <button type="submit" class="btn btn-primary" id="ruleModalSaveButton">
+              保存
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"


### PR DESCRIPTION
## Summary
- add a Bootstrap modal for editing firewall rules with dropdowns for chain, target, protocol, and addresses
- expose normalized detail keys from the parser so the frontend can prefill port fields
- replace the prompt-based rule editing flow with the modal form that assembles the specification string

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd93fe3a0832bb5d0de7c62bff28b