### PR TITLE
Define escapeHtml helper for frontend rendering

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,6 +2,16 @@ const CHAIN_OPTIONS = ["INPUT", "OUTPUT", "FORWARD", "PREROUTING", "POSTROUTING"
 const TARGET_OPTIONS = ["ACCEPT", "DROP", "REJECT", "LOG", "RETURN"];
 const PROTOCOL_OPTIONS = ["tcp", "udp", "icmp", "all"];
 const ADDRESS_OPTIONS = ["0.0.0.0/0", "127.0.0.1", "192.168.0.0/16", "10.0.0.0/8", "::/0"];
+
+const escapeHtml = (value) => {
+  const div = document.createElement("div");
+  div.textContent = value ?? "";
+  return div.innerHTML;
+};
+
+if (typeof window !== "undefined") {
+  window.escapeHtml = window.escapeHtml || escapeHtml;
+}
 const PORT_KEYS = new Set(["dpt", "dport", "spt", "sport"]);
 const state = {
   chains: [],


### PR DESCRIPTION
## Summary
- add a DOM-based escapeHtml helper to sanitize rendered firewall rule text
- expose the helper on the window object to avoid reference errors in other scripts

## Testing
- not run (frontend reload required manually)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d150b10832b90aa5e85feb815dc